### PR TITLE
Use label "ByT5" instead of "t5" to avoid confusion.

### DIFF
--- a/plot_amp.py
+++ b/plot_amp.py
@@ -88,7 +88,7 @@ def set_experiment_paths(experiment):
         "SIP-ISL": f"{EXPERIMENT_HEADER}_*local_isl_isl_*",
         "SIP-FST": f"{EXPERIMENT_HEADER}_*SIP_None*",
         "SIP-TSL": f"{EXPERIMENT_HEADER}_*local_tsl_tsl_canon*",
-        "t5": f"{EXPERIMENT_HEADER}_*t5_None*",
+        "ByT5": f"{EXPERIMENT_HEADER}_*t5_None*",
     }
 
 def metric2label(metric: Literal["acc", "edit_dist", "inform"]) -> str:
@@ -170,7 +170,7 @@ def loadScores(root: str) -> pd.DataFrame:
 def plotSingle(
     data: pd.DataFrame,
     task: Literal["ae->aA", "a.e->a.A", "a.?e->a.?A", "a.*e->a.*A"],
-    model: Literal["SIP-ISL", "SIP-FST", "t5"],
+    model: Literal["SIP-ISL", "SIP-FST", "ByT5"],
     metric: Literal["acc", "edit_dist", "inform"],
     cipher: Literal["facet", "aggregate", "remove"],
 ):
@@ -194,7 +194,7 @@ def plotSingle(
 
 def plotModelByTaskGrid(
     data: pd.DataFrame,
-    models: List[Literal["SIP-ISL", "SIP-FST", "t5"]],
+    models: List[Literal["SIP-ISL", "SIP-FST", "ByT5"]],
     tasks: List[Literal["ae->aA", "a.e->a.A", "a.?e->a.?A", "a.*e->a.*A"]],
     metric: Literal["acc", "edit_dist", "inform"],
     cipher: Literal["facet", "aggregate", "remove"],
@@ -226,7 +226,7 @@ def plotModelByTaskGrid(
 
 def plotModelByTaskOverlay(
     data: pd.DataFrame,
-    models: List[Literal["SIP-ISL", "SIP-FST", "t5"]],
+    models: List[Literal["SIP-ISL", "SIP-FST", "ByT5"]],
     tasks: List[Literal["ae->aA", "a.e->a.A", "a.?e->a.?A", "a.*e->a.*A"]],
     metric: Literal["acc", "edit_dist", "inform"],
     cipher: Literal["facet", "aggregate", "remove"],

--- a/plot_amp_ivv.py
+++ b/plot_amp_ivv.py
@@ -24,7 +24,7 @@ DATA_PATHS = {
     "SIP-ISL": "ivv_*_local_isl_isl_*",
     "SIP-TSL": "ivv_*_local_tsl_tsl_*",
     "SIP-FST": "ivv_*_SIP_None",
-    "t5": "ivv_*_t5_None",
+    "ByT5": "ivv_*_t5_None",
 }
 
 
@@ -76,7 +76,7 @@ def loadScores(root: str) -> pd.DataFrame:
 def plotSingle(
     data: pd.DataFrame,
     task: Literal["da->Da", "da->DDa", "ad->aD", "ad->aDD", "ada->aDa", "ada->aDDa"],
-    model: Literal["SIP-ISL", "SIP-FST", "t5"],
+    model: Literal["SIP-ISL", "SIP-FST", "ByT5"],
     metric: Literal["acc", "edit_dist", "inform"],
 ):
     """Plots a single metric from `data` with bootstrapped confidence region.
@@ -94,7 +94,7 @@ def plotSingle(
 
 def plotModelByTaskGrid(
     data: pd.DataFrame,
-    models: List[Literal["SIP-ISL", "SIP-FST", "t5"]],
+    models: List[Literal["SIP-ISL", "SIP-FST", "ByT5"]],
     tasks: List[Literal["ae->aA", "a.e->a.A", "a.?e->a.?A", "a.*e->a.*A"]],
     metric: Literal["acc", "edit_dist", "inform"],
 ):
@@ -121,7 +121,7 @@ def plotModelByTaskGrid(
 
 def plotModelByTaskOverlay(
     data: pd.DataFrame,
-    models: List[Literal["SIP-ISL", "SIP-FST", "t5"]],
+    models: List[Literal["SIP-ISL", "SIP-FST", "ByT5"]],
     tasks: List[Literal["ae->aA", "a.e->a.A", "a.?e->a.?A", "a.*e->a.*A"]],
     metric: Literal["acc", "edit_dist", "inform"],
 ):


### PR DESCRIPTION
I wasn't able to test this because I don't have any recent experiment outputs to run it on. Hope this tweak to labels doesn't do anything unexpected because of the hacky way we map between labels and data directories.